### PR TITLE
fix for incorrect RDL file format

### DIFF
--- a/hog.cpp
+++ b/hog.cpp
@@ -206,17 +206,17 @@ void Quads(const Cube& cube, std::vector<Quad>* quads)
   // Neighbours:
   enum Neighbour
   {
-    Left,
-    Top,
     Right,
+    Top,
+    Left,
     Bottom,
     Back,
     Front
   };
 
-  if (cube.neighbors[Left] == -1)
+  if (cube.neighbors[Right] == -1)
   {
-    const Quad quad = { vertices[0], vertices[1], vertices[5], vertices[4] };
+    const Quad quad = { vertices[2], vertices[3], vertices[7], vertices[6] };
     quads->push_back(quad);
   }
 
@@ -226,9 +226,9 @@ void Quads(const Cube& cube, std::vector<Quad>* quads)
     quads->push_back(quad);
   }
 
-  if (cube.neighbors[Right] == -1)
+  if (cube.neighbors[Left] == -1)
   {
-    const Quad quad = { vertices[2], vertices[3], vertices[7], vertices[6] };
+    const Quad quad = { vertices[0], vertices[1], vertices[5], vertices[4] };
     quads->push_back(quad);
   }
 


### PR DESCRIPTION
Right face should be read in first rather than Left. Previous version resulted in strange artefacts where Left and Right walls are drawn on the opposite face.

I observed some very odd behaviour in the original functionality - I believe that the description of the RDL file format at https://web.archive.org/web/20081120054017/http://www.descent2.com/ddn/specs/rdl may be incorrect. The above fix allowed me to solve the strange behaviours. 

Also many thanks for the repo - has proved quite useful for me to work with the Descent maps for pathfinding! 